### PR TITLE
Migrate to append-only response headers to support multiple headers

### DIFF
--- a/ktor-core/src/org/jetbrains/ktor/http/Application.kt
+++ b/ktor-core/src/org/jetbrains/ktor/http/Application.kt
@@ -10,13 +10,13 @@ fun ApplicationRequest.header(name: String): String? = headers[name]?.singleOrNu
 fun ApplicationRequest.parameter(name: String): String? = parameters[name]?.singleOrNull()
 
 fun ApplicationResponse.contentType(value: ContentType) = contentType(value.toString())
-fun ApplicationResponse.contentType(value: String) = header(HttpHeaders.ContentType, value)
-fun ApplicationResponse.header(name: String, value: Int) = header(name, value.toString())
-fun ApplicationResponse.header(name: String, date: Temporal) = header(name, date.toHttpDateString())
+fun ApplicationResponse.contentType(value: String) = headers.append(HttpHeaders.ContentType, value)
+fun ApplicationResponse.header(name: String, value: Int) = headers.append(name, value.toString())
+fun ApplicationResponse.header(name: String, date: Temporal) = headers.append(name, date.toHttpDateString())
 
 fun ApplicationResponse.sendRedirect(url: String, permanent: Boolean = false): ApplicationRequestStatus {
     status(if (permanent) HttpStatusCode.MovedPermanently else HttpStatusCode.Found)
-    header(HttpHeaders.Location, url)
+    headers.append(HttpHeaders.Location, url)
     return ApplicationRequestStatus.Handled
 }
 
@@ -28,7 +28,7 @@ fun ApplicationResponse.sendError(code: HttpStatusCode, message: String = code.d
 
 fun ApplicationResponse.sendAuthenticationRequest(realm: String): ApplicationRequestStatus {
     status(HttpStatusCode.Unauthorized)
-    header(HttpHeaders.WWWAuthenticate, "Basic realm=\"$realm\"")
+    headers.append(HttpHeaders.WWWAuthenticate, "Basic realm=\"$realm\"")
     streamText("Not authorized")
     return ApplicationRequestStatus.Handled
 }

--- a/ktor-core/test/org/jetbrains/ktor/tests/application/HandlerTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/application/HandlerTest.kt
@@ -92,7 +92,7 @@ class HandlerTest {
 
     Test fun `application with handler that intercepts creation of headers`() = withTestApplication {
         application.intercept { handler ->
-            response.interceptHeader { name, value, header ->
+            response.headers.intercept { name, value, header ->
                 if (name == "Content-Type" && value == "text/plain")
                     header(name, "text/xml")
                 else
@@ -112,7 +112,7 @@ class HandlerTest {
                     assertEquals(ApplicationRequestStatus.Asynchronous, it.requestResult)
                 }
                 it("should have modified content type to text/xml") {
-                    assertEquals("text/xml", it.response.header("Content-Type"))
+                    assertEquals("text/xml", it.response.headers["Content-Type"])
                 }
             }
         }

--- a/ktor-samples/ktor-samples-json/src/org/jetbrains/ktor/samples/json/JsonApplication.kt
+++ b/ktor-samples/ktor-samples-json/src/org/jetbrains/ktor/samples/json/JsonApplication.kt
@@ -20,7 +20,7 @@ class JsonApplication(config: ApplicationConfig) : Application(config) {
     init {
         intercept { next ->
             if (request.acceptEncoding()?.contains("deflate") ?: false) {
-                response.header(HttpHeaders.ContentEncoding, "deflate")
+                response.headers.append(HttpHeaders.ContentEncoding, "deflate")
                 response.interceptStream { content, stream ->
                     stream {
                         DeflaterOutputStream(this).apply {

--- a/ktor-servlet/src/org/jetbrains/ktor/servlet/ServletApplicationResponse.kt
+++ b/ktor-servlet/src/org/jetbrains/ktor/servlet/ServletApplicationResponse.kt
@@ -7,19 +7,20 @@ import java.io.*
 import javax.servlet.http.*
 
 public class ServletApplicationResponse(private val servletResponse: HttpServletResponse) : ApplicationResponse {
-    private val header = Interceptable2<String, String, Unit> { name, value ->
-        servletResponse.setHeader(name, value)
-    }
-
     var _status: HttpStatusCode? = null
     private val status = Interceptable1<HttpStatusCode, Unit> { code ->
         _status = code
         servletResponse.status = code.value
     }
 
-    public override fun header(name: String): String = servletResponse.getHeader(name)
-    public override fun header(name: String, value: String) = header.call(name, value)
-    public override fun interceptHeader(handler: (String, String, (String, String) -> Unit) -> Unit) = header.intercept(handler)
+    override val headers: ResponseHeaders = object: ResponseHeaders() {
+        override fun hostAppendHeader(name: String, value: String) {
+            servletResponse.addHeader(name, value)
+        }
+
+        override fun getHostHeaderNames(): List<String> = servletResponse.headerNames.toList()
+        override fun getHostHeaderValues(name: String): List<String> = servletResponse.getHeaders(name).toList()
+    }
 
     public override fun status(): HttpStatusCode? = _status
     public override fun status(value: HttpStatusCode) = status.call(value)


### PR DESCRIPTION
`ResponseHeaders` class encapsulates headers response logic including intercepting, reduces code duplication in host implementations

- Functions `header(name)`, `header(name, value)` and `interceptHeaders` are removed and added property `headers: ReponseHeaders` that contains corresponding functions: `get(name)`, `append(name, value)` and `intercept(handler)`

- Notice `ResponseHeaders.append(name, value)` is self-descriptive so it is clear for user that it appends header rather than set/replace existing value(s)

- Function `contians` function useful to test whether we have header set. For example:
```
if (HttpHeaders.ContentType !in response.headers) {
    response.contentType(ContentType.Any)
}
```
- Function `values(name)` provides a list of header values
- Function `allValues()` constructs `ValuesMap` of all headers